### PR TITLE
use global vs window for SSR

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 
-function useEventListener(eventName, callback, element = window) {
+function useEventListener(eventName, callback, element = global) {
   const savedCallback = useRef()
 
   useEffect(


### PR DESCRIPTION
if using on SSR you get this error:

```
ReferenceError: window is not defined
```

because there is no `window` in Node.js. `global` will work everywhere